### PR TITLE
nginx+php-fpm evironment for webasyst

### DIFF
--- a/install/rhel/7/templates/web/nginx/php-fpm/webasyst.sh
+++ b/install/rhel/7/templates/web/nginx/php-fpm/webasyst.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+user="$1"
+domain="$2"
+ip="$3"
+home_dir="$4"
+docroot="$5"
+pool_conf="
+[$2]
+listen = /run/php7.4-fpm-$2.sock
+listen.owner = $1
+listen.group = nginx
+listen.mode = 0660
+
+user = $1
+group = $1
+
+pm = ondemand
+pm.max_children = 4
+pm.max_requests = 4000
+pm.process_idle_timeout = 10s
+pm.status_path = /status
+
+php_admin_value[upload_tmp_dir] = /home/$1/tmp
+php_admin_value[session.save_path] = /home/$1/tmp
+php_admin_value[open_basedir] = /home/$1/.composer:/home/$1/web/$2/public_html:/home/$1/web/$2/private:/home/$1/web/$2/public_shtml:/home/$1/tmp:/tmp:/var/www/html:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
+php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f $1@$2
+
+env[PATH] = /usr/local/bin:/usr/bin:/bin
+env[TMP] = /home/$1/tmp
+env[TMPDIR] = /home/$1/tmp
+env[TEMP] = /home/$1/tmp
+"
+
+fastcgi_param="
+fastcgi_param SCRIPT_FILENAME     $document_root$fastcgi_script_name;
+fastcgi_param PATH_INFO           $fastcgi_path_info;
+
+fastcgi_param  QUERY_STRING       $query_string;
+fastcgi_param  REQUEST_METHOD     $request_method;
+fastcgi_param  CONTENT_TYPE       $content_type;
+fastcgi_param  CONTENT_LENGTH     $content_length;
+
+fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+fastcgi_param  REQUEST_URI        $request_uri;
+fastcgi_param  DOCUMENT_URI       $document_uri;
+fastcgi_param  DOCUMENT_ROOT      $document_root;
+fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+fastcgi_param  REQUEST_SCHEME     $scheme;
+fastcgi_param  HTTPS              $https if_not_empty;
+
+fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+
+fastcgi_param  REMOTE_ADDR        $remote_addr;
+fastcgi_param  REMOTE_PORT        $remote_port;
+fastcgi_param  SERVER_ADDR        $server_addr;
+fastcgi_param  SERVER_PORT        $server_port;
+fastcgi_param  SERVER_NAME        $server_name;
+
+# PHP only, required if PHP was built with --enable-force-cgi-redirect
+fastcgi_param  REDIRECT_STATUS    200;"
+
+pool_file_74="/etc/opt/remi/php74/php-fpm.d/$2.conf"
+    
+# если репозиторий remi есть, то устанавливаем php73-php-fpm, иначе - выход
+if [ -f /etc/yum.repos.d/remi-php74.repo ] ; then
+    yum install php74-php-fpm php74-php-mbstring php74-php-curl php74-php-gd php74-php-zlib php74-php-gettext
+        else
+            echo "check this https://blog.remirepo.net/post/2019/12/03/Install-PHP-7.4-on-CentOS-RHEL-or-Fedora"
+        exit 0
+fi
+
+if [ -f "/etc/opt/remi/php74/php-fpm.d/www.conf" ]; then
+    rm -f /etc/opt/remi/php74/php-fpm.d/www.conf
+fi
+
+find /etc/opt/remi/*/php-fpm.d/ -type f -name "$2.conf" -delete
+echo "$fastcgi_param" > /etc/nginx/wa-fastcgi_params
+
+if [ -f "$pool_file_74" ]; then
+        rm -f $pool_file_74
+        echo "$pool_conf" > $pool_file_74
+        systemctl restart php74-php-fpm
+
+        else
+                echo "$pool_conf" > $pool_file_74
+                systemctl restart php74-php-fpm
+fi
+
+exit 0

--- a/install/rhel/7/templates/web/nginx/php-fpm/webasyst.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/webasyst.stpl
@@ -1,0 +1,148 @@
+server {
+
+    listen      %ip%:%web_ssl_port% ssl http2;
+    server_name %domain_idn% %alias_idn%;
+
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    ssl_buffer_size 4k;
+
+    ssl_session_timeout 4h;
+
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    try_files $uri $uri/ /index.php?$query_string;
+
+    location /index.php {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+    }
+    
+    # for install only
+    location /install.php {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+    }    
+    
+    location /api.php {
+        fastcgi_split_path_info  ^(.+\.php)(.*)$;
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+    }
+    
+    location ~ /(oauth.php|link.php|payments.php) {
+        try_files $uri $uri/ /index.php?$query_string;
+    }    
+
+    location ^~ /wa-data/protected/ {
+        internal;
+    }
+    
+    location ~ /wa-content {
+        allow all;
+    }
+
+    location ^~ /(wa-apps|wa-plugins|wa-system|wa-widgets)/.*/(lib|locale|templates)/ {
+        deny all;
+    }
+
+    location ~* ^/wa-(cache|config|installer|log|system)/ {
+        return 403;
+    }
+
+    location ~* ^/wa-data/public/contacts/photos/[0-9]+/ {
+         root %docroot%;
+         access_log off;
+         expires  30d;
+         error_page   404  =  @contacts_thumb;
+    }
+
+    location @contacts_thumb {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/contacts/photos/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/contacts/photos/thumb.php;
+    }
+  
+    # photos app
+    location ~* ^/wa-data/public/photos/[0-9]+/ {
+        access_log   off;
+        expires      30d;
+        error_page   404  =  @photos_thumb;
+    }
+
+    location @photos_thumb {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/photos/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/photos/thumb.php;
+    }
+    # end photos app
+    
+    # shop app
+    location ~* ^/wa-data/public/shop/products/[0-9]+/ {
+        access_log   off;
+        expires      30d;
+        error_page   404  =  @shop_thumb;
+    }
+    location @shop_thumb {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/shop/products/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/shop/products/thumb.php;
+    }
+    
+    location ~* ^/wa-data/public/shop/promos/[0-9]+ {
+        access_log   off;
+        expires      30d;
+        error_page   404  =  @shop_promo;
+    }
+    location @shop_promo {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/shop/promos/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/shop/promos/thumb.php;
+    }
+    # end shop app
+    
+    # mailer app
+    location ~* ^/wa-data/public/mailer/files/[0-9]+/ {
+        access_log   off;
+        error_page   404  =  @mailer_file;
+    }
+    location @mailer_file {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/mailer/files/file.php;
+        fastcgi_param  SCRIPT_FILENAME $document_root/wa-data/public/mailer/files/file.php;
+    }
+    # end mailer app
+
+    location ~* ^.+\.(%proxy_extentions%)$ {
+        access_log   off;
+        expires      30d;
+    }
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+ include     /etc/nginx/conf.d/phpmyadmin.inc*;
+ include     /etc/nginx/conf.d/phppgadmin.inc*;
+ include     /etc/nginx/conf.d/webmail.inc*;
+
+ include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/rhel/7/templates/web/nginx/php-fpm/webasyst.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/webasyst.tpl
@@ -1,0 +1,137 @@
+server {
+
+    listen      %ip%:%proxy_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    try_files $uri $uri/ /index.php?$query_string;
+
+    location /index.php {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+    }
+    
+    # for install only
+    location /install.php {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+    }    
+    
+    location /api.php {
+        fastcgi_split_path_info  ^(.+\.php)(.*)$;
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+    }
+    
+    location ~ /(oauth.php|link.php|payments.php) {
+        try_files $uri $uri/ /index.php?$query_string;
+    }    
+
+    location ^~ /wa-data/protected/ {
+        internal;
+    }
+    
+    location ~ /wa-content {
+        allow all;
+    }
+
+    location ^~ /(wa-apps|wa-plugins|wa-system|wa-widgets)/.*/(lib|locale|templates)/ {
+        deny all;
+    }
+
+    location ~* ^/wa-(cache|config|installer|log|system)/ {
+        return 403;
+    }
+
+    location ~* ^/wa-data/public/contacts/photos/[0-9]+/ {
+         root %docroot%;
+         access_log off;
+         expires  30d;
+         error_page   404  =  @contacts_thumb;
+    }
+
+    location @contacts_thumb {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/contacts/photos/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/contacts/photos/thumb.php;
+    }
+  
+    # photos app
+    location ~* ^/wa-data/public/photos/[0-9]+/ {
+        access_log   off;
+        expires      30d;
+        error_page   404  =  @photos_thumb;
+    }
+
+    location @photos_thumb {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/photos/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/photos/thumb.php;
+    }
+    # end photos app
+    
+    # shop app
+    location ~* ^/wa-data/public/shop/products/[0-9]+/ {
+        access_log   off;
+        expires      30d;
+        error_page   404  =  @shop_thumb;
+    }
+    location @shop_thumb {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/shop/products/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/shop/products/thumb.php;
+    }
+    
+    location ~* ^/wa-data/public/shop/promos/[0-9]+ {
+        access_log   off;
+        expires      30d;
+        error_page   404  =  @shop_promo;
+    }
+    location @shop_promo {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/shop/promos/thumb.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root/wa-data/public/shop/promos/thumb.php;
+    }
+    # end shop app
+    
+    # mailer app
+    location ~* ^/wa-data/public/mailer/files/[0-9]+/ {
+        access_log   off;
+        error_page   404  =  @mailer_file;
+    }
+    location @mailer_file {
+        include /etc/nginx/wa-fastcgi_params;
+        fastcgi_pass  unix:/run/php7.4-fpm-%domain_idn%.sock;
+        fastcgi_param  SCRIPT_NAME  /wa-data/public/mailer/files/file.php;
+        fastcgi_param  SCRIPT_FILENAME $document_root/wa-data/public/mailer/files/file.php;
+    }
+    # end mailer app
+
+    location ~* ^.+\.(%proxy_extentions%)$ {
+        access_log   off;
+        expires      30d;
+    }
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+ include     /etc/nginx/conf.d/phpmyadmin.inc*;
+ include     /etc/nginx/conf.d/phppgadmin.inc*;
+ include     /etc/nginx/conf.d/webmail.inc*;
+
+ include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}


### PR DESCRIPTION
nginx configuration based on official documentation: https://developers.webasyst.ru/docs/installation/tips/nginx-fastcgi/
By default, with environment work under Centos 7 and remi's repo. Release for last php version, which support by webasyst - 7.4. But you may switch it to another php version